### PR TITLE
Fix CDN imports and add default block

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Projektant klocków 6×6×12 cm</title>
     <link rel="stylesheet" href="styles.css" />
+    <script type="importmap">
+      {
+        "imports": {
+          "three": "https://unpkg.com/three@0.156.1/build/three.module.js",
+          "three/examples/jsm/controls/OrbitControls.js": "https://unpkg.com/three@0.156.1/examples/jsm/controls/OrbitControls.js"
+        }
+      }
+    </script>
   </head>
   <body>
     <div id="app"></div>

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,5 @@
-import * as THREE from 'https://unpkg.com/three@0.156.1/build/three.module.js';
-import { OrbitControls } from 'https://unpkg.com/three@0.156.1/examples/jsm/controls/OrbitControls.js';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
 
 const BLOCK_SIZE = { x: 6, y: 12, z: 6 }; // cm units
 const GRID_LIMIT = 10; // how many blocks allowed from center on X/Z
@@ -301,6 +301,8 @@ window.addEventListener('resize', () => {
 
 const resetButton = document.querySelector('#reset');
 const exportButton = document.querySelector('#export');
+
+addBlock({ x: 0, y: 0, z: 0 });
 
 resetButton.addEventListener('click', clearScene);
 exportButton.addEventListener('click', exportLayout);


### PR DESCRIPTION
## Summary
- declare an import map so three.js modules resolve correctly when hosted
- use the mapped specifiers in the main scene script
- spawn a starter block at the origin when the app loads

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e400fea1e08322b93d221308eb3754