### PR TITLE
Add textured blocks and 90° rotation support

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
       <p>
         Lewy przycisk myszy – dodawanie klocka w podświetlonym miejscu.<br />
         <kbd>Shift</kbd> + lewy przycisk – usuwanie wskazanego klocka.<br />
+        <kbd>R</kbd> / <kbd>Shift</kbd>+<kbd>R</kbd> – obrót klocka o 90° w przód/tył.<br />
         Rolka myszy/gesty – przybliżenie, obrót widoku wykonujemy przeciągając myszą.
       </p>
       <div class="controls">


### PR DESCRIPTION
## Summary
- apply procedural canvas-based textures to the block model for top/bottom and side faces so no binary assets are required
- implement orientation-aware placement so blocks can be rotated in 90° steps and lie horizontally
- update placement validation, export payload, and UI instructions for the new rotation control

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4064cec388322b16693da709c1cab