### PR TITLE
Update Canon SELPHY 1500 stereopair defaults

### DIFF
--- a/Strona WWW/kreatorStereopary.html
+++ b/Strona WWW/kreatorStereopary.html
@@ -465,11 +465,11 @@
                         <div class="stereopair-dimensions">
                             <label class="stereopair-field" for="workspaceWidth">
                                 <span class="stereopair-field-label">Szerokość (cm)</span>
-                                <input type="number" id="workspaceWidth" min="1" step="0.1" value="12.5" />
+                                <input type="number" id="workspaceWidth" min="1" step="0.1" value="15" />
                             </label>
                             <label class="stereopair-field" for="workspaceHeight">
                                 <span class="stereopair-field-label">Wysokość (cm)</span>
-                                <input type="number" id="workspaceHeight" min="1" step="0.1" value="11" />
+                                <input type="number" id="workspaceHeight" min="1" step="0.1" value="10" />
                             </label>
                         </div>
                         <p class="stereopair-helper-text">Podaj rozmiar końcowego pliku do druku. Podgląd skaluje się automatycznie na ekranie telefonu.</p>
@@ -493,8 +493,8 @@
                             <label class="stereopair-field" for="columnGapRange">
                                 <span class="stereopair-field-label">Odstęp między kolumnami (mm)</span>
                                 <div class="stereopair-slider-inputs">
-                                    <input type="range" id="columnGapRange" min="0" max="30" value="8" step="1" />
-                                    <input type="number" id="columnGapNumber" min="0" max="30" value="8" step="1" />
+                                    <input type="range" id="columnGapRange" min="0" max="30" value="6" step="1" />
+                                    <input type="number" id="columnGapNumber" min="0" max="30" value="6" step="1" />
                                 </div>
                             </label>
                         </div>
@@ -502,8 +502,8 @@
                             <label class="stereopair-field" for="rowGapRange">
                                 <span class="stereopair-field-label">Odstęp między wierszami (mm)</span>
                                 <div class="stereopair-slider-inputs">
-                                    <input type="range" id="rowGapRange" min="0" max="30" value="12" step="1" />
-                                    <input type="number" id="rowGapNumber" min="0" max="30" value="12" step="1" />
+                                    <input type="range" id="rowGapRange" min="0" max="30" value="0" step="1" />
+                                    <input type="number" id="rowGapNumber" min="0" max="30" value="0" step="1" />
                                 </div>
                             </label>
                         </div>
@@ -514,11 +514,11 @@
                         <div class="stereopair-dimensions">
                             <label class="stereopair-field" for="topMargin">
                                 <span class="stereopair-field-label">Margines górny i dolny (mm)</span>
-                                <input type="number" id="topMargin" min="0" max="30" value="5" step="0.5" />
+                                <input type="number" id="topMargin" min="0" max="30" value="1" step="0.5" />
                             </label>
                             <label class="stereopair-field" for="sideMargin">
                                 <span class="stereopair-field-label">Margines boczny (mm)</span>
-                                <input type="number" id="sideMargin" min="0" max="30" value="5" step="0.5" />
+                                <input type="number" id="sideMargin" min="0" max="30" value="16" step="0.5" />
                             </label>
                         </div>
                     </section>
@@ -542,7 +542,7 @@
 
                 <div class="stereopair-preview">
                     <div class="stereopair-preview-header">
-                        <span class="stereopair-workspace-label" id="workspaceLabel">Obszar roboczy 12,5×11 cm</span>
+                        <span class="stereopair-workspace-label" id="workspaceLabel">Obszar roboczy 15×10 cm</span>
                     </div>
                     <div class="stereopair-workspace" id="workspace">
                         <div class="stereopair-image-half stereopair-image-half-left" id="photo1-left">
@@ -685,12 +685,12 @@
         const templates = {
             'canon-selphy-1500': {
                 label: 'Canon SELPHY 1500',
-                workspaceWidthCm: 12.5,
-                workspaceHeightCm: 11,
-                columnGapMm: 8,
-                rowGapMm: 12,
-                topMarginMm: 5,
-                sideMarginMm: 5,
+                workspaceWidthCm: 15,
+                workspaceHeightCm: 10,
+                columnGapMm: 6,
+                rowGapMm: 0,
+                topMarginMm: 1,
+                sideMarginMm: 16,
             },
         };
 


### PR DESCRIPTION
## Summary
- set Canon SELPHY 1500 default canvas size to 15×10 cm
- adjust default gaps and margins to requested values
- refresh preview label to reflect new defaults


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b5534e80483229b0fa9ed3c09c484)